### PR TITLE
MultipathServiceType

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		1CC3288420D9BE5F0099644D /* Joke.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Joke.swift; sourceTree = "<group>"; };
 		1CC3288820D9BEC70099644D /* Joke+Endpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Joke+Endpoint.swift"; sourceTree = "<group>"; };
 		1CC3288B20D9C4A80099644D /* Atom.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Atom.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C79112E24D0979E00DC6E00 /* Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -79,6 +80,7 @@
 		1C48198D20D034E200CB6F31 /* Example */ = {
 			isa = PBXGroup;
 			children = (
+				4C79112E24D0979E00DC6E00 /* Example.entitlements */,
 				1C4819A920D0356100CB6F31 /* Controllers */,
 				1CC3288620D9BEA50099644D /* Extensions */,
 				1CC3288020D9BE1A0099644D /* Global */,
@@ -377,6 +379,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Example/Example.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = H562758AXX;
 				INFOPLIST_FILE = Example/Info.plist;
@@ -395,6 +398,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Example/Example.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = H562758AXX;
 				INFOPLIST_FILE = Example/Info.plist;

--- a/Example/Example/Example.entitlements
+++ b/Example/Example/Example.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.networking.multipath</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Example/Global/Constants.swift
+++ b/Example/Example/Global/Constants.swift
@@ -19,7 +19,8 @@ import Foundation
 
 /// Global instance of Atom networking library.
 internal let atom: Atom = {
-    let atom = Atom()
+    let configuration = Atom.ServiceConfiguration(multipathServiceType: .handover)
+    let atom = Atom(serviceConfiguration: configuration)
     atom.log = .on
 
     return atom

--- a/Framework/Atom/Service/Atom+ServiceConfiguration.swift
+++ b/Framework/Atom/Service/Atom+ServiceConfiguration.swift
@@ -31,6 +31,9 @@ public extension Atom {
         /// The queue to dispatch `Result` object on.
         internal let dispatchQueue: DispatchQueue
 
+        /// The service type that specifies the Multipath TCP connection policy for transmitting data over Wi-Fi and cellular interfaces.
+        internal let multipathServiceType: MultipathServiceType
+
         /// The standardized timeout interval for request and resource.
         internal let timeout: Atom.ServiceConfiguration.Timeout
 
@@ -50,6 +53,19 @@ public extension Atom {
             case ephemeral
         }
 
+        /// Constants that specify the type of service that Multipath TCP uses.
+        ///
+        /// The multipath service type determines whether multipath TCP should be attempted and the conditions
+        /// for creating and switching between subflows. Using these service types requires the appropriate entitlement. Any
+        /// connection attempt will fail if the process does not have the required entitlement.
+        ///
+        /// Available options are:
+        ///  - `.none`        - The default service type indicating that Multipath TCP should not be used.
+        ///  - `.handover`    - A Multipath TCP service that provides seamless handover between Wi-Fi and cellular in order to preserve the connection.
+        ///  - `.interactive` - A service whereby Multipath TCP attempts to use the lowest-latency interface.
+        ///  - `.aggregate`   - A service that aggregates the capacities of other Multipath options in an attempt to increase throughput and minimize latency.
+        public typealias MultipathServiceType = URLSessionConfiguration.MultipathServiceType
+
         /// Creates a `ServiceConfiguration` instance given the provided parameter(s).
         ///
         /// - Parameters:
@@ -57,11 +73,13 @@ public extension Atom {
         ///   - configuration:        The `Atom.ServiceConfiguration.Configuration` - default value is `.ephemeral`.
         ///   - decoder:              The `JSONDecoder` for decoding data into models.
         ///   - dispatchQueue:        The queue to dispatch `Result` object on.
-        public init(authenticationMethod: Atom.AuthenticationMethod = .none, configuration: Atom.ServiceConfiguration.Configuration = .ephemeral, decoder: JSONDecoder = JSONDecoder(), dispatchQueue: DispatchQueue = .main) {
+        ///   - multipathServiceType: The service type that specifies the Multipath TCP connection policy for transmitting data over Wi-Fi and cellular interfaces.
+        public init(authenticationMethod: AuthenticationMethod = .none, configuration: Configuration = .ephemeral, decoder: JSONDecoder = JSONDecoder(), dispatchQueue: DispatchQueue = .main, multipathServiceType: MultipathServiceType = .none) {
             self.authenticationMethod = authenticationMethod
             self.configuration = configuration
             self.decoder = decoder
             self.dispatchQueue = dispatchQueue
+            self.multipathServiceType = multipathServiceType
             self.timeout = Timeout()
         }
     }
@@ -85,6 +103,7 @@ internal extension Atom.ServiceConfiguration {
 
         sessionConfiguration.timeoutIntervalForRequest = timeout.request
         sessionConfiguration.timeoutIntervalForResource = timeout.resource
+        sessionConfiguration.multipathServiceType = multipathServiceType
 
         return sessionConfiguration
     }


### PR DESCRIPTION
Add the ability to configure `Atom.Service` using `URLSessionConfiguration.MultipathServiceType`.

The multipath service type determines whether multipath TCP should be attempted and the conditions for creating and switching between subflows. Using these service types requires the appropriate entitlement. Any connection attempt will fail if the process does not have the required entitlement.

Available options are:
* `.none` - The default service type indicating that Multipath TCP should not be used.
* `.handover` - A Multipath TCP service that provides seamless handover between Wi-Fi and cellular in order to preserve the connection.
* `.interactive` - A service whereby Multipath TCP attempts to use the lowest-latency interface.
* `.aggregate` - A service that aggregates the capacities of other Multipath options in an attempt to increase throughput and minimize latency.