### PR TITLE
Async Await

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -237,7 +237,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1220;
-				LastUpgradeCheck = 1220;
+				LastUpgradeCheck = 1300;
 				TargetAttributes = {
 					4C4E42E7258ADD2B009AF14F = {
 						CreatedOnToolsVersion = 12.2;
@@ -436,7 +436,7 @@
 				DEVELOPMENT_TEAM = VV4VQB3X2M;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = iOS/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -458,7 +458,7 @@
 				DEVELOPMENT_TEAM = VV4VQB3X2M;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = iOS/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -478,6 +478,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = macOS/macOS.entitlements;
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = VV4VQB3X2M;
@@ -488,7 +489,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.alaskaair.Example;
 				PRODUCT_NAME = Example;
 				SDKROOT = macosx;
@@ -502,6 +503,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = macOS/macOS.entitlements;
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = VV4VQB3X2M;
@@ -512,7 +514,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.alaskaair.Example;
 				PRODUCT_NAME = Example;
 				SDKROOT = macosx;

--- a/Example/Shared/Views/ContentView.swift
+++ b/Example/Shared/Views/ContentView.swift
@@ -24,7 +24,6 @@ struct ContentView: View {
     var body: some View {
         content
             .edgesIgnoringSafeArea(.all)
-            .onAppear { model.random() }
     }
 
     // MARK: Content
@@ -43,7 +42,9 @@ struct ContentView: View {
 
                 Spacer()
 
-                Button(action: { model.random() }) {
+                Button {
+                    Task { try? await model.random() }
+                } label: {
                     Text("REFRESH")
                         .fontWeight(.bold)
                         .foregroundColor(.yellow)

--- a/Example/Shared/Views/ContentViewModel.swift
+++ b/Example/Shared/Views/ContentViewModel.swift
@@ -18,16 +18,17 @@ import Atom
 import Combine
 import Foundation
 
+@MainActor
 final class ContentViewModel: ObservableObject {
     /// The joke to display on successful fetch.
     @Published var joke: Joke = .default
 
     /// Fetches a random joke.
-    func random() {
-        atom
-            .enqueue(Joke.Endpoint.random)
-            .resume(expecting: Joke.self)
-            .replaceError(with: .default)
-            .assign(to: &$joke)
+    func random() async throws {
+        do {
+            joke = try await atom
+                .enqueue(Joke.Endpoint.random)
+                .resume(expecting: Joke.self)
+        } catch { joke = .default }
     }
 }

--- a/Framework/.swiftlint.yml
+++ b/Framework/.swiftlint.yml
@@ -6,7 +6,6 @@ disabled_rules:
 - nesting
 - pattern_matching_keywords
 - private_over_fileprivate
-- private_unit_testing
 - identifier_name
 - vertical_whitespace
 - trailing_whitespace
@@ -29,7 +28,6 @@ opt_in_rules:
 - legacy_random
 - let_var_whitespace
 - literal_expression_end_indentation
-- missing_empty_line
 - modifier_order
 - object_literal
 - operator_usage_whitespace
@@ -43,7 +41,6 @@ opt_in_rules:
 - trailing_closure
 - unneeded_parentheses_in_closure_argument
 - untyped_error_in_catch
-- unused_private_declaration
 - unused_import
 - vertical_parameter_alignment_on_call
 - yoda_condition

--- a/Framework/Atom.xcodeproj/project.pbxproj
+++ b/Framework/Atom.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		4C92FD19224E6A6100D16767 /* Result+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C92FD18224E6A6100D16767 /* Result+Additions.swift */; };
 		4C96B7142360B6CB0021EDB8 /* Response+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C96B7132360B6CB0021EDB8 /* Response+Additions.swift */; };
 		4C973FD3237372EC006B2736 /* AuthenticationMethod+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C973FD2237372EC006B2736 /* AuthenticationMethod+Additions.swift */; };
+		4C98D6EB2696A5720074AC83 /* Service+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C98D6EA2696A5720074AC83 /* Service+AsyncAwait.swift */; };
 		4CA6564D242189E000E35D9F /* URLSessionTaskMetrics+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA6564C242189E000E35D9F /* URLSessionTaskMetrics+Additions.swift */; };
 		4CAB5A69242012E900E4FB97 /* Interceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CAB5A68242012E900E4FB97 /* Interceptor.swift */; };
 		4CAB5A6C2420217E00E4FB97 /* OSLog+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CAB5A6B2420217E00E4FB97 /* OSLog+Additions.swift */; };
@@ -165,6 +166,7 @@
 		4C92FD18224E6A6100D16767 /* Result+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Additions.swift"; sourceTree = "<group>"; };
 		4C96B7132360B6CB0021EDB8 /* Response+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Response+Additions.swift"; sourceTree = "<group>"; };
 		4C973FD2237372EC006B2736 /* AuthenticationMethod+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AuthenticationMethod+Additions.swift"; sourceTree = "<group>"; };
+		4C98D6EA2696A5720074AC83 /* Service+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Service+AsyncAwait.swift"; sourceTree = "<group>"; };
 		4CA6564C242189E000E35D9F /* URLSessionTaskMetrics+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSessionTaskMetrics+Additions.swift"; sourceTree = "<group>"; };
 		4CAB5A68242012E900E4FB97 /* Interceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interceptor.swift; sourceTree = "<group>"; };
 		4CAB5A6B2420217E00E4FB97 /* OSLog+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OSLog+Additions.swift"; sourceTree = "<group>"; };
@@ -285,6 +287,7 @@
 			isa = PBXGroup;
 			children = (
 				1CC3281D20D844610099644D /* Service.swift */,
+				4C98D6EA2696A5720074AC83 /* Service+AsyncAwait.swift */,
 				4C4E42C3258AC311009AF14F /* Service+Combine.swift */,
 				1CC3280B20D813E70099644D /* ServiceConfiguration.swift */,
 				4C31600C221DE0BE00E853F5 /* ServiceConfiguration+Timeout.swift */,
@@ -595,7 +598,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if test -d \"/opt/homebrew/bin/\"; then\n  PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\n\nexport PATH\n\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -628,6 +631,7 @@
 				4C7B86002372361F00FA85FC /* AuthorizationEndpoint.swift in Sources */,
 				1C241795216687100032A994 /* RequestableError.swift in Sources */,
 				1CC3287B20D9990F0099644D /* URLRequest+Additions.swift in Sources */,
+				4C98D6EB2696A5720074AC83 /* Service+AsyncAwait.swift in Sources */,
 				4C316011221E0C8300E853F5 /* AtomResponse.swift in Sources */,
 				4C316027221F0E5400E853F5 /* Data+Additions.swift in Sources */,
 				4C6A0D3923DBC28300A64975 /* Atom+Notifications.swift in Sources */,

--- a/Framework/Atom.xcodeproj/xcshareddata/xcschemes/Atom.xcscheme
+++ b/Framework/Atom.xcodeproj/xcshareddata/xcschemes/Atom.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Framework/Atom/Protocols/Delegates/AuthenticationManagerDelegate.swift
+++ b/Framework/Atom/Protocols/Delegates/AuthenticationManagerDelegate.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /// The `AuthenticationManagerDelegate` protocol provides an interface for responding to `AuthenticationManager` events.
-internal protocol AuthenticationManagerDelegate: class {
+internal protocol AuthenticationManagerDelegate: AnyObject {
     /// Notifies the delegate when the `AuthenticationManager` successfully refreshed the access token.
     func authenticationManagerDidRefreshAccessToken()
 

--- a/Framework/Atom/Protocols/Types/TokenCredentialWritable.swift
+++ b/Framework/Atom/Protocols/Types/TokenCredentialWritable.swift
@@ -34,7 +34,7 @@ import Foundation
 /// ```
 ///
 /// For more information see `Configuration` documentation.
-public protocol TokenCredentialWritable: class {
+public protocol TokenCredentialWritable: AnyObject {
     /// Returns conforming type as `TokenCredential`.
     var tokenCredential: TokenCredential { get set }
 }

--- a/Framework/Atom/Service/Service+AsyncAwait.swift
+++ b/Framework/Atom/Service/Service+AsyncAwait.swift
@@ -1,6 +1,6 @@
 // Atom
 //
-// Copyright (c) 2020 Alaska Airlines
+// Copyright (c) 2021 Alaska Airlines
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,10 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Combine
 import Foundation
 
-@available(iOS 13.0, macOS 10.15, *)
+@available(iOS 15.0, macOS 12.0, *)
 public extension Service {
     /// Creates and resumes `URLRequest` initialized from `Requestable`.
     ///
@@ -29,30 +28,26 @@ public extension Service {
     ///
     /// A typical usage pattern for this method could look like this:
     ///
-    /// ````
-    /// atom
+    /// ```
+    /// let user = try await atom
     ///     .enqueue(endpoint)
     ///     .resume(expecting: User.self)
-    ///     .sink { completion in
-    ///         // Handle `AtomError`.
-    ///     } receiveValue: { user in
-    ///         // Handle decoded `User` instance.
-    ///     }
-    ///     .store(in: &cancelables)
-    /// ````
+    /// ```
     ///
     /// In the above example, data will be decoded into a `User` instance.
     ///
     /// - Parameters:
     ///   - type: The type to decode.
     ///
-    /// - Returns: `AnyPublisher` where `Output` is the decoded `Model` and `Failure` is `AtomError`.
-    func resume<T>(expecting type: T.Type) -> AnyPublisher<T, AtomError> where T: Model {
-        Future { promise in
+    /// - Throws: `AtomError` instance if an error occurred.
+    ///
+    /// - Returns: Decoded `Model` instance.
+    func resume<T>(expecting type: T.Type) async throws -> T where T: Model {
+        try await withCheckedThrowingContinuation { continuation in
             self.resume(expecting: type) {
-                promise($0)
+                continuation.resume(with: $0)
             }
-        }.eraseToAnyPublisher()
+        }
     }
 
     /// Creates and resumes `URLRequest` initialized from `Requestable`.
@@ -63,26 +58,22 @@ public extension Service {
     /// `Atom` framework uses a convenience computed variable on `AtomResponse` - `isSuccessful`
     /// to determine success or a failure of a response based on a status code returned by the service.
     ///
-    /// A typical usage pattern for this method after getting a `result` could look like this:
-    /// 
-    /// ````
-    /// atom
+    /// A typical usage pattern for this method could look like this:
+    ///
+    /// ```
+    /// let response = try await atom
     ///     .enqueue(endpoint)
     ///     .resume()
-    ///     .sink {
-    ///         // Handle `AtomError`.
-    ///     } receiveValue: {
-    ///         // Handle `AtomResponse`.
-    ///     }
-    ///     .store(in: &cancelables)
-    /// ````
+    /// ```
     ///
-    /// - Returns: `AnyPublisher` where `Output` is the `AtomResponse` and `Failure` is `AtomError`.
-    func resume() -> AnyPublisher<AtomResponse, AtomError> {
-        Future { promise in
+    /// - Throws: `AtomError` instance if an error occurred.
+    ///
+    /// - Returns: `AtomResponse` instance.
+    func resume() async throws -> AtomResponse {
+        try await withCheckedThrowingContinuation { continuation in
             self.resume {
-                promise($0)
+                continuation.resume(with: $0)
             }
-        }.eraseToAnyPublisher()
+        }
     }
 }


### PR DESCRIPTION
* Bump up the target of the Example app to iOS 15 and update the example code to use the new async-await API.
* Introduce async-await support.
* Remove deprecated SwiftLint rules.
* Update protocol requirements from `class` to `AnyObject`.
* Update settings for Xcode 13.