### PR TITLE
KV: Setting timeout as part of ServiceConfiguration

### DIFF
--- a/Example/Shared/Global/Constants.swift
+++ b/Example/Shared/Global/Constants.swift
@@ -19,7 +19,7 @@ import Foundation
 
 /// Global instance of Atom networking library.
 let atom: Atom = {
-    let configuration = ServiceConfiguration(multipathServiceType: .handover)
+    let configuration = ServiceConfiguration(multipathServiceType: .handover, timeout: ServiceConfiguration.Timeout(request: 60, resource: 60))
     let atom = Atom(serviceConfiguration: configuration)
     atom.log = true
 

--- a/Example/Shared/Global/Constants.swift
+++ b/Example/Shared/Global/Constants.swift
@@ -19,7 +19,8 @@ import Foundation
 
 /// Global instance of Atom networking library.
 let atom: Atom = {
-    let configuration = ServiceConfiguration(multipathServiceType: .handover, timeout: ServiceConfiguration.Timeout(request: 60, resource: 60))
+    let timeout = ServiceConfiguration.Timeout(request: 60, resource: 60)
+    let configuration = ServiceConfiguration(multipathServiceType: .handover, timeout: timeout)
     let atom = Atom(serviceConfiguration: configuration)
     atom.log = true
 

--- a/Framework/Atom/Service/ServiceConfiguration+Timeout.swift
+++ b/Framework/Atom/Service/ServiceConfiguration+Timeout.swift
@@ -27,7 +27,7 @@ public extension ServiceConfiguration {
         
         /// Object to set `URLSessionConfiguration` timeouts
         /// - Parameters:
-        ///   - request: Double - The timeout interval to use when waiting for additional data.
+        ///   - request:  Double - The timeout interval to use when waiting for additional data.
         ///   - resource: Double - The maximum amount of time that a resource request should be allowed to take.
         public init(request: Double = 30.0, resource: Double = 30.0) {
             self.request = request

--- a/Framework/Atom/Service/ServiceConfiguration+Timeout.swift
+++ b/Framework/Atom/Service/ServiceConfiguration+Timeout.swift
@@ -16,13 +16,23 @@
 
 import Foundation
 
-internal extension ServiceConfiguration {
+public extension ServiceConfiguration {
     /// Model object representing `URLSessionConfiguration` timeout intervals.
     struct Timeout {
         /// The timeout interval to use when waiting for additional data.
-        internal let request = 30.0
+        internal var request: Double
 
         /// The maximum amount of time that a resource request should be allowed to take.
-        internal let resource = 30.0
+        internal var resource: Double
+
+        
+        /// Object to set `URLSessionConfiguration` timeouts
+        /// - Parameters:
+        ///   - request: Double - The timeout interval to use when waiting for additional data.
+        ///   - resource: Double - The maximum amount of time that a resource request should be allowed to take.
+        public init(request: Double = 30.0, resource: Double = 30.0) {
+            self.request = request
+            self.resource = resource
+        }
     }
 }

--- a/Framework/Atom/Service/ServiceConfiguration+Timeout.swift
+++ b/Framework/Atom/Service/ServiceConfiguration+Timeout.swift
@@ -24,7 +24,6 @@ public extension ServiceConfiguration {
 
         /// The maximum amount of time that a resource request should be allowed to take.
         internal var resource: Double
-
         
         /// Object to set `URLSessionConfiguration` timeouts
         /// - Parameters:

--- a/Framework/Atom/Service/ServiceConfiguration.swift
+++ b/Framework/Atom/Service/ServiceConfiguration.swift
@@ -74,13 +74,15 @@ public final class ServiceConfiguration {
     ///   - decoder:              The `JSONDecoder` for decoding data into models.
     ///   - dispatchQueue:        The queue to dispatch `Result` object on.
     ///   - multipathServiceType: The service type that specifies the Multipath TCP connection policy for transmitting data over Wi-Fi and cellular interfaces.
-    public init(authenticationMethod: AuthenticationMethod = .none, configuration: Configuration = .ephemeral, decoder: JSONDecoder = JSONDecoder(), dispatchQueue: DispatchQueue = .main, multipathServiceType: MultipathServiceType = .none) {
+    ///   - timeout:              Timeout interval needed for URLSessionConfiguration.
+
+    public init(authenticationMethod: AuthenticationMethod = .none, configuration: Configuration = .ephemeral, decoder: JSONDecoder = JSONDecoder(), dispatchQueue: DispatchQueue = .main, multipathServiceType: MultipathServiceType = .none, timeout: Timeout = Timeout()) {
         self.authenticationMethod = authenticationMethod
         self.configuration = configuration
         self.decoder = decoder
         self.dispatchQueue = dispatchQueue
         self.multipathServiceType = multipathServiceType
-        self.timeout = Timeout()
+        self.timeout = timeout
     }
 
     #else
@@ -92,12 +94,13 @@ public final class ServiceConfiguration {
     ///   - configuration:        The `ServiceConfiguration.Configuration` - default value is `.ephemeral`.
     ///   - decoder:              The `JSONDecoder` for decoding data into models.
     ///   - dispatchQueue:        The queue to dispatch `Result` object on.
-    public init(authenticationMethod: AuthenticationMethod = .none, configuration: Configuration = .ephemeral, decoder: JSONDecoder = JSONDecoder(), dispatchQueue: DispatchQueue = .main) {
+    ///   - timeout:              Timeout interval needed for URLSessionConfiguration.
+    public init(authenticationMethod: AuthenticationMethod = .none, configuration: Configuration = .ephemeral, decoder: JSONDecoder = JSONDecoder(), dispatchQueue: DispatchQueue = .main, timeout: Timeout = Timeout()) {
         self.authenticationMethod = authenticationMethod
         self.configuration = configuration
         self.decoder = decoder
         self.dispatchQueue = dispatchQueue
-        self.timeout = Timeout()
+        self.timeout = timeout
     }
     #endif
 }

--- a/Framework/AtomTests/Models/ServiceConfigurationTests.swift
+++ b/Framework/AtomTests/Models/ServiceConfigurationTests.swift
@@ -26,4 +26,15 @@ internal class ServiceConfigurationTests: BaseCase {
         XCTAssertEqual(serviceConfiguration.dispatchQueue, .main)
         XCTAssertEqual(serviceConfiguration.configuration, .ephemeral)
     }
+
+    internal func testServiceConfigurationInitializationWithTimeout() {
+        // Given, When
+        let timeout = ServiceConfiguration.Timeout(request: 60, resource: 60)
+        let serviceConfiguration = ServiceConfiguration(timeout: timeout)
+
+        // Then
+        XCTAssertEqual(serviceConfiguration.timeout.request, 60)
+        XCTAssertEqual(serviceConfiguration.timeout.resource, 60)
+    }
+
 }


### PR DESCRIPTION
- Allows clients to set timeout as part of service configuration to there desired interval.
*Note - If clients don't set any time out then ServiceConfiguration will default to 30 sec.
- Update Service configuration initializers to take in timeout.
- Open up timeout intializer only to set both resource and request intervals.
- Unit tests