### PR TITLE
MB: Add Optional Per-Call JSONDecoder (AB#1615795)

### DIFF
--- a/Framework/AtomNetworking/Atom/Service/Service.swift
+++ b/Framework/AtomNetworking/Atom/Service/Service.swift
@@ -74,11 +74,12 @@ public final class Service: Sendable {
     /// occurs and all concurrent callers wait for it.
     ///
     /// - Parameters:
-    ///   - type: The expected response model type.
+    ///   - type:    The expected response model type.
+    ///   - decoder: An optional decoder to use for this call only. Omit (or pass `nil`) to use the service-configured decoder.
     ///
     /// - Returns: The decoded response.
-    public func resume<T>(expecting type: T.Type) async throws(AtomError) -> T where T: Model {
-        try await serviceActor.resume(for: requestable, expecting: type)
+    public func resume<T>(expecting type: T.Type, decoder: JSONDecoder? = nil) async throws(AtomError) -> T where T: Model {
+        try await serviceActor.resume(for: requestable, expecting: type, decoder: decoder)
     }
 
     /// Executes the request using async/await and returns the raw response.
@@ -95,9 +96,10 @@ public final class Service: Sendable {
     ///
     /// - Parameters:
     ///   - type:       The expected response model type.
+    ///   - decoder:    An optional decoder to use for this call only. Omit (or pass `nil`) to use the service-configured decoder.
     ///   - completion: Called with the result.
-    public func resume<T>(expecting type: T.Type, completion: @Sendable @escaping (Result<T, AtomError>) -> Void) where T: Model {
-        Task { await serviceActor.resume(for: requestable, expecting: type, completion: completion) }
+    public func resume<T>(expecting type: T.Type, decoder: JSONDecoder? = nil, completion: @Sendable @escaping (Result<T, AtomError>) -> Void) where T: Model {
+        Task { await serviceActor.resume(for: requestable, expecting: type, decoder: decoder, completion: completion) }
     }
 
     /// Executes the request using a completion handler and returns the raw response.

--- a/Framework/AtomNetworking/Atom/Service/ServiceActor+Async.swift
+++ b/Framework/AtomNetworking/Atom/Service/ServiceActor+Async.swift
@@ -31,14 +31,15 @@ extension ServiceActor {
     /// - Parameters:
     ///   - requestable: The request to execute.
     ///   - type:        The expected model type conforming to `Model`.
+    ///   - decoder:     An optional decoder to use for this call only. Omit (or pass `nil`) to use the service-configured decoder.
     ///
     /// - Returns: The decoded model of type `T`.
     /// - Throws:  `AtomError` on failure (e.g., network errors or decoding issues).
-    func resume<T: Model>(for requestable: any Requestable, expecting type: T.Type) async throws(AtomError) -> T {
+    func resume<T: Model>(for requestable: any Requestable, expecting type: T.Type, decoder: JSONDecoder? = nil) async throws(AtomError) -> T {
         let response = try await deduplicatedResponse(for: requestable)
 
         guard let value = response.data as? T else {
-            return try serviceConfiguration.decoder.decode(type: type, from: response.data)
+            return try (decoder ?? serviceConfiguration.decoder).decode(type: type, from: response.data)
         }
 
         return value

--- a/Framework/AtomNetworking/Atom/Service/ServiceActor+Completions.swift
+++ b/Framework/AtomNetworking/Atom/Service/ServiceActor+Completions.swift
@@ -27,12 +27,18 @@ extension ServiceActor {
     /// - Parameters:
     ///   - requestable: The request to execute.
     ///   - type:        The expected model type conforming to `Model`.
+    ///   - decoder:     An optional decoder to use for this call only. Omit (or pass `nil`) to use the service-configured decoder.
     ///   - completion:  A `@Sendable` escaping closure called with the result.
-    func resume<T: Model>(for requestable: any Requestable, expecting type: T.Type, completion: @Sendable @escaping (Result<T, AtomError>) -> Void) {
+    func resume<T: Model>(
+        for requestable: any Requestable,
+        expecting type: T.Type,
+        decoder: JSONDecoder? = nil,
+        completion: @Sendable @escaping (Result<T, AtomError>) -> Void
+    ) {
         Task {
             do {
                 // Perform the async resume operation on the session actor.
-                let value = try await resume(for: requestable, expecting: type)
+                let value = try await resume(for: requestable, expecting: type, decoder: decoder)
 
                 // Dispatch the success completion asynchronously to the specified queue (e.g., for UI/main thread safety).
                 serviceConfiguration.dispatchQueue.async {


### PR DESCRIPTION
## Introduction:
This Pull Request adds an optional per-call decoder to Atom. Both public `resume(expecting:)` overloads now accept an optional `decoder: JSONDecoder?`. When a caller supplies one, that decoder is used for that single request; when it is omitted, Atom falls back to the decoder on `ServiceConfiguration`, exactly as before.

`ServiceConfiguration` already lets you set one decoder for a whole service. This change adds the missing granularity: a single service can now decode one endpoint with a custom strategy while every other endpoint keeps the default - without standing up a second service.

These changes are additive and do not break existing source compatibility.

## Motivation:
A `ServiceConfiguration` carries a single decoder, so every request through that `Atom` instance decodes the same way. That is the right default, but it is all-or-nothing: the moment one endpoint needs a different strategy - a date-decoding strategy for string dates, or key handling for a payload whose casing differs from the rest of the service - the only options today are to change the decoder for the entire service or to build a second `Atom` just for that one call.

Lowering the whole service to the most lenient decoder erodes the contract for every other endpoint; a second service duplicates configuration and connection setup for a single request. What was missing is a way to say "this one call decodes differently," right where the call happens.

## Proposed Solution:

### 1. Accept an Optional Decoder at the Call Site
Both public `resume(expecting:)` overloads gain `decoder: JSONDecoder? = nil`. Because the parameter defaults to `nil`, every existing call site compiles unchanged.

```swift
public func resume<T>(
    expecting type: T.Type,
    decoder: JSONDecoder? = nil
) async throws(AtomError) -> T where T: Model {
    try await serviceActor.resume(for: requestable, expecting: type, decoder: decoder)
}

public func resume<T>(
    expecting type: T.Type,
    decoder: JSONDecoder? = nil,
    completion: @Sendable @escaping (Result<T, AtomError>) -> Void
) where T: Model {
    Task { await serviceActor.resume(for: requestable, expecting: type, decoder: decoder, completion: completion) }
}
```

### 2. Fall Back to the Service Decoder
The parameter is threaded through `ServiceActor` to the single decode site. When it is `nil`, decoding uses `serviceConfiguration.decoder` - the existing behavior. Nothing else in the path moves; the de-duplication call and the raw-response passthrough are untouched.

```swift
guard let value = response.data as? T else {
    return try (decoder ?? serviceConfiguration.decoder).decode(type: type, from: response.data)
}
```

### 3. Keep It Stateless
The decoder rides with the request as a plain value parameter rather than living as mutable state on `Atom` or the actor. Two concurrent calls can therefore never affect one another's decoding, and there is nothing new to make `Sendable`. This also composes cleanly with in-flight de-duplication: the coalescing key is method + URL only, so two callers that share one network call each decode the shared bytes with their own decoder.

### Scope
Decoder only. The raw-response `resume()` overloads (no `expecting:`) do not decode and are unchanged, and there is no matching change to `JSONEncoder`. `ServiceConfiguration.decoder` remains the default for every call that does not pass its own.

## Additional Info:
* Adds `decoder: JSONDecoder? = nil` to both public `resume(expecting:)` overloads (async and completion).
* Falls back to `ServiceConfiguration.decoder` when omitted - existing behavior is preserved.
* Keeps the override stateless, so it is safe under concurrency and under in-flight de-duplication.
* Updated the doc-comments on the affected overloads.

## Testing
* Library builds clean under Swift 6 strict concurrency; all existing unit tests pass.
* Verified end-to-end with a temporary `URLProtocol`-stubbed harness (not included in this diff): a per-call decoder reaches the decode site through every hop; omitting it falls back to the service-configured decoder; a mismatched decoder surfaces `AtomError.decoder`. Exercised for both the async and completion overloads.

## Source Compatibility:
Please check the box to indicate the impact of this proposal on source compatibility.

* [x] This change is additive and does not impact existing source code.
* [ ] This change breaks existing source code.

## Reminders:
* [x] Check the branch this PR is against.
* [x] Add your initials in the PR title: "MB: Add Optional Per-Call JSONDecoder"
* [x] Add your initials in the PR branch: "as/principals/1615795-atom-optional-jsondecoder"
* [x] For Reviewers:
    * Perform user testing (if applicable).
    * Check written tests (if applicable).

## Summary by Sourcery

Add support for specifying an optional per-call JSONDecoder when resuming typed Atom requests, while preserving existing service-level decoder behavior.

New Features:
- Allow callers to pass an optional JSONDecoder to typed Service.resume(expecting:) APIs for both async and completion-based calls.

Enhancements:
- Route the optional decoder through ServiceActor and use it at the single decode site, falling back to the service-configured decoder when omitted.
- Update doc-comments on affected resume(expecting:) APIs to document the per-call decoder behavior.